### PR TITLE
Added additional yaml object validation.

### DIFF
--- a/bentoudev/dataclass/yaml_loader.py
+++ b/bentoudev/dataclass/yaml_loader.py
@@ -454,6 +454,9 @@ def DictToDataclass(clazz: type, yaml_obj: Any, context: DataclassVisitorContext
         return result
 
     else:
+        clazz_fields = list(dataclasses.fields(clazz))
+        validate_dataclass_fields(clazz, {}, clazz_fields, context)
+
         result = yaml_obj
         handle_source_tracked(result)
         return result

--- a/tests/test_load_dataclass.py
+++ b/tests/test_load_dataclass.py
@@ -457,3 +457,15 @@ def test_track_yaml_source():
 
     check_field(result.nested, 'f_str_array', 8, 3, 'test.yml')
     check_field(result.nested.f_str_array, 'data', 9, 5, 'test.yml')
+
+
+@pytest.mark.skip(reason="Test fails - this is a bug.")
+def test_raise_when_yaml_subobject_is_none():
+    yaml_str = (
+        'f_nested:\n'
+        'f_nested_array:\n'
+    )
+
+    # f_nested is missing its fields, such input should raise error
+    with pytest.raises(base.DataclassLoadError):
+        result = yaml.load_yaml_dataclass(root_class, 'test.yml', yaml_str)

--- a/tests/test_load_dataclass.py
+++ b/tests/test_load_dataclass.py
@@ -459,7 +459,6 @@ def test_track_yaml_source():
     check_field(result.nested.f_str_array, 'data', 9, 5, 'test.yml')
 
 
-@pytest.mark.skip(reason="Test fails - this is a bug.")
 def test_raise_when_yaml_subobject_is_none():
     yaml_str = (
         'f_nested:\n'


### PR DESCRIPTION
Consider the yaml in added unit test:
```
f_nested:
f_nested_array:
```
where no child fields are present in the `f_nested` field. In such case, the `DictToDataclass` function receives `None` in the `yaml_obj` argument. The dataclass type of `f_nested` requires fields to be present, and none of them are `Optional` - therefore, input fields are missing, which should be reported as an error. This change adds the validation that makes the unit test pass.
